### PR TITLE
fix(checkbox): alignment tweak based on new focus padding

### DIFF
--- a/packages/components/src/components/checkbox/_checkbox.scss
+++ b/packages/components/src/components/checkbox/_checkbox.scss
@@ -98,7 +98,7 @@
   .#{$prefix}--checkbox-label::after {
     position: absolute;
     top: rem(8px);
-    left: rem(6px);
+    left: rem(7px);
     width: rem(9px);
     height: rem(5px);
     margin-top: rem(-3px);


### PR DESCRIPTION
Closes #8061

Small tweak to center the check inside the checkbox based on the recent padding/outline updates from https://github.com/carbon-design-system/carbon/pull/7887

#### Changelog
**Changed**

- checkbox check positioning

#### Testing / Reviewing

Checkbox story should show the check is horizontally centered within the checkbox with and without focus ring.
